### PR TITLE
Prevent duplicate pairings

### DIFF
--- a/src/components/PairingForm.tsx
+++ b/src/components/PairingForm.tsx
@@ -64,7 +64,7 @@ const PairingForm = ({ members, refresh }: PairingFormProps) => {
 
     setSubmitting(true);
     // Create pairing in database
-    await fetch(`/api/pairings`, {
+    const response = await fetch(`/api/pairings`, {
       method: 'POST',
       headers: {
         'Content-type': 'application/json',
@@ -75,11 +75,14 @@ const PairingForm = ({ members, refresh }: PairingFormProps) => {
         semester,
       }),
     });
+    const result = await response.json();
 
     toast({
-      title: 'Success!',
-      description: 'Successfully added pairing.',
-      status: 'success',
+      title: result.success ? 'Success!' : 'Error',
+      description: result.success
+        ? 'Successfully added pairing.'
+        : result.message,
+      status: result.success ? 'success' : 'error',
     });
 
     setSubmitting(false);

--- a/src/firebase/pairings.ts
+++ b/src/firebase/pairings.ts
@@ -60,7 +60,12 @@ export const addPairing = async (
   adingId: string | undefined,
   semesterAssigned: string
 ) => {
-  if (!akId || !adingId) return;
+  if (!akId || !adingId) {
+    return {
+      success: false,
+      message: 'AK or Ading ID is missing from arguments.',
+    };
+  }
 
   const membersCollection = db.collection(MEMBERS_COL);
 
@@ -70,12 +75,15 @@ export const addPairing = async (
   const adingRef = membersCollection.doc(adingId);
   const adingDoc = await adingRef.get();
 
-  // Check that members do exist; if not, TODO: throw error
+  // Check that members do exist
   if (!akDoc.exists || !adingDoc.exists) {
-    return;
+    return {
+      success: false,
+      message: 'AK or Ading document of specified ID does not exist.',
+    };
   }
 
-  // Check that pairing does not already exist; if so, TODO: throw error
+  // Check that pairing does not already exist
   const pairingsCollection = db.collection(PAIRINGS_COL);
   const pairingRef = pairingsCollection
     .where('ak', '==', akRef)
@@ -83,7 +91,10 @@ export const addPairing = async (
 
   const existingPairingResult = await pairingRef.get();
   if (!existingPairingResult.empty) {
-    return;
+    return {
+      success: false,
+      message: 'Pairing with specified AK and ading already exists',
+    };
   }
 
   // Update members to have additional AK/ading
@@ -98,6 +109,12 @@ export const addPairing = async (
 
   // Add pairing to db
   await pairingsCollection.add(pairing);
+
+  return {
+    success: true,
+    message: 'Successfully added pairing.',
+    pairing,
+  };
 };
 
 /**

--- a/src/firebase/pairings.ts
+++ b/src/firebase/pairings.ts
@@ -70,8 +70,19 @@ export const addPairing = async (
   const adingRef = membersCollection.doc(adingId);
   const adingDoc = await adingRef.get();
 
-  // TODO: better error handling
+  // Check that members do exist; if not, TODO: throw error
   if (!akDoc.exists || !adingDoc.exists) {
+    return;
+  }
+
+  // Check that pairing does not already exist; if so, TODO: throw error
+  const pairingsCollection = db.collection(PAIRINGS_COL);
+  const pairingRef = pairingsCollection
+    .where('ak', '==', akRef)
+    .where('ading', '==', adingRef);
+
+  const existingPairingResult = await pairingRef.get();
+  if (!existingPairingResult.empty) {
     return;
   }
 
@@ -86,7 +97,6 @@ export const addPairing = async (
   };
 
   // Add pairing to db
-  const pairingsCollection = db.collection(PAIRINGS_COL);
   await pairingsCollection.add(pairing);
 };
 

--- a/src/pages/api/pairings.ts
+++ b/src/pages/api/pairings.ts
@@ -24,8 +24,10 @@ const apiGetPairings = async (res: NextApiResponse) => {
 
 const apiCreatePairing = async (req: NextApiRequest, res: NextApiResponse) => {
   const { akId, adingId, semester } = req.body;
-  await addPairing(akId, adingId, semester);
-  return res.status(200).send({});
+  const result = await addPairing(akId, adingId, semester);
+  const status = result.success ? 200 : 400;
+  
+  return res.status(status).send(result);
 }
 
 const apiUpdatePairing = async (req: NextApiRequest, res: NextApiResponse) => {


### PR DESCRIPTION
Closes #20 

- [x] prevent duplicate pairings from being created through request
- [x] send error to frontend if duplicate pairing is requested
- [x] display error on frontend